### PR TITLE
feat: improved recipe form UX and validation

### DIFF
--- a/src/lib/validation/recipe.ts
+++ b/src/lib/validation/recipe.ts
@@ -6,11 +6,17 @@ export const RecipeSchema = z.object({
   prepTime: z.coerce.number().min(0, "Prep time must be at least 0"),
   cookTime: z.coerce.number().min(0, "Cook time must be at least 0"),
   servings: z.coerce.number().min(1, "Servings must be at least 1"),
-  difficulty: z.string().min(1, "Difficulty is required"),
+  difficulty: z.enum(["Easy", "Medium", "Hard", "Unknown"]),
   cuisine: z.string().min(1, "Cuisine is required"),
   calories: z.coerce.number().min(0, "Calories must be at least 0"),
   image: z.string().url("Image must be a valid URL").optional(),
-  ingredients: z.array(z.string().min(1, "No empty ingredient")).min(1, "At least one ingredient required"),
+  ingredients: z.array(
+    z.object({
+      name: z.string().min(1, "Ingredient name required"),
+      amount: z.coerce.number().min(0, "Amount must be at least 0"),
+      unit: z.string().min(1, "Unit required"),
+    })
+  ).min(1, "At least one ingredient required"),
   tags: z.array(z.string()).optional(),
   mealType: z.array(z.string()).optional(),
 });


### PR DESCRIPTION
Zusammenfassung für Konstantin – Mögliche DB-Änderungen
	•	difficulty als ENUM ergänzen/aktualisieren:
Werte: 'Easy', 'Medium', 'Hard', 'Unknown'
	•	cuisine-Feld anpassen:
Als VARCHAR/TEXT oder als ENUM (plus eigenes Textfeld für “Other”)
	•	servings als INTEGER speichern (Mindestwert: 1)
	•	ingredients müssen folgendes unterstützen:
	•	name (string)
	•	amount (number/float)
	•	unit (string)
	•	und mehrere Zutaten pro Rezept ermöglichen (also Array/Relation)
	•	tags und mealType können als TEXT-Array (z.B. PostgreSQL text[]) oder 
	        als eigene Join-Tabelle angelegt werden – je nach Bedarf.
	        
	    