### PR TITLE
change api for ingredients

### DIFF
--- a/src/app/api/recipes/[id]/ingredients/route.ts
+++ b/src/app/api/recipes/[id]/ingredients/route.ts
@@ -13,6 +13,15 @@ export async function GET(
   }
 
   try {
+    const [recipe] = await db
+      .select({ servings: schema.recipes.servings })
+      .from(schema.recipes)
+      .where(eq(schema.recipes.id, recipeId));
+
+    if (!recipe) {
+      return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
+    }
+
     const ingredients = await db
       .select({
         name: schema.ingredients.name,
@@ -22,7 +31,10 @@ export async function GET(
       .from(schema.ingredients)
       .where(eq(schema.ingredients.recipeId, recipeId));
 
-    return NextResponse.json(ingredients);
+    return NextResponse.json({
+      servings: recipe.servings,
+      ingredients,
+    });
   } catch (error) {
     console.error("GET /api/recipes/[id]/ingredients failed:", error);
     return NextResponse.json(

--- a/src/lib/fetchIngredients.ts
+++ b/src/lib/fetchIngredients.ts
@@ -1,8 +1,8 @@
-import type { Ingredient } from "@/types/recipe";
+import type { IngredientsServings } from "@/types/recipe";
 
 export async function fetchIngredients(
   recipeId: number
-): Promise<Ingredient[]> {
+): Promise<IngredientsServings> {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/recipes/${recipeId}/ingredients`,
     {
@@ -14,6 +14,6 @@ export async function fetchIngredients(
     throw new Error("Failed to fetch ingredients");
   }
 
-  const data: Ingredient[] = await res.json();
+  const data: IngredientsServings = await res.json();
   return data;
 }

--- a/src/types/recipe.d.ts
+++ b/src/types/recipe.d.ts
@@ -47,6 +47,11 @@ export type Ingredient = {
   unit: Unit;
 };
 
+export type IngredientsServings = {
+  servings: number;
+  ingredients: Ingredient[];
+};
+
 export type RecipeFormData = {
   name?: string;
   instructions?: string[];


### PR DESCRIPTION
Change to the Ingredients API

1. The API route
`GET /api/recipes/[id]/ingredients`
no longer returns just an array of ingredients. Instead, it now returns an object that includes both the list of ingredients and the number of servings.

**Before:**
The response was an array of type Ingredient[]
Example:
```
[
  { "name": "Flour", "amount": 100, "unit": "grams" },
  { "name": "Sugar", "amount": 50, "unit": "grams" }
]
```
**Now:**
The response is an object of type:
```
type IngredientsServings = {
  servings: number;
  ingredients: Ingredient[];
};
```
Example:
```
{
  "servings": 4,
  "ingredients": [
    { "name": "Flour", "amount": 100, "unit": "grams" },
    { "name": "Sugar", "amount": 50, "unit": "grams" }
  ]
}
```
**fetchIngredients() now returns an object, not just an array.**

**How to use**
After the change, fetchIngredients() returns an object:

```
type IngredientsServings = {
  servings: number;
  ingredients: Ingredient[];
};
```

Example UI integration:

```
<RecipeCardIngredient 
  ingredients={ingredients} 
  servings={servings} 
/>
```

Make sure your component props accept servings now:

```
type RecipeCardIngredientProps = {
  ingredients: Ingredient[];
  servings: number;
};
```